### PR TITLE
feat: Kenesis 연동 설정과 이상치 rule-based 라벨링 설정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     // S3
     implementation "software.amazon.awssdk:s3:2.31.29"
+
+    // Kinesis
+    implementation("org.apache.flink:flink-connector-kinesis:5.0.0-1.20")
 }
 test {
     useJUnitPlatform()

--- a/src/main/java/com/monitory/data/transformations/DangerLevelAssigner.java
+++ b/src/main/java/com/monitory/data/transformations/DangerLevelAssigner.java
@@ -1,0 +1,91 @@
+package com.monitory.data.transformations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.api.common.functions.MapFunction;
+
+public class DangerLevelAssigner implements MapFunction<String, String>  {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String map(String value) throws Exception {
+        ObjectNode jsonNode = (ObjectNode) mapper.readTree(value);
+
+        String sensorType = "";
+        double sensorValue = Double.NaN;
+        int dangerLevel = 0;
+
+        if (jsonNode.has("sensorType") && jsonNode.get("sensorType").isTextual()) {
+            sensorType = jsonNode.get("sensorType").asText();
+        } else {
+            jsonNode.put("dangerLevel", "unknown_type");
+            return mapper.writeValueAsString(jsonNode);
+        }
+
+        if (jsonNode.has("val") && jsonNode.get("val").isNumber()) {
+            sensorValue = jsonNode.get("val").asDouble();
+        } else {
+            jsonNode.put("dangerLevel", "invalid_value");
+            return mapper.writeValueAsString(jsonNode);
+        }
+
+        // 출처: https://facto-real.atlassian.net/wiki/spaces/~557058e02db5ec8a1448f1a1ab0ae5d196e126/pages/22806599
+        switch (sensorType.toLowerCase()) {
+            case "temp":
+                if (sensorValue > 40.0) {
+                    dangerLevel = 2;
+                } else if (sensorValue < -35) {
+                    dangerLevel = 2;
+                } else if (sensorValue < 25 || sensorValue > 30) {
+                    dangerLevel = 1;
+                }
+                break;
+
+            case "humid":
+                if (sensorValue >= 80.0) {
+                    dangerLevel = 2;
+                } else if (sensorValue > 60 && sensorValue < 80.0) {
+                    dangerLevel = 1;
+                }
+                break;
+
+            case "vibration":
+                if (sensorValue > 7.1) {
+                    dangerLevel = 2;
+                } else if (sensorValue > 2.8 && sensorValue <= 7.1) {
+                    dangerLevel = 1;
+                }
+                break;
+
+            case "current":
+                if (sensorValue > 30) { // 예시 임계값 (ppm)
+                    dangerLevel = 2;
+                } else if (sensorValue >= 7 && sensorValue <= 30) {
+                    dangerLevel = 1;
+                }
+                break;
+
+            case "dust":
+                if (sensorValue > 150) {
+                    dangerLevel = 2;
+                } else if (sensorValue > 75 && sensorValue <= 150) {
+                    dangerLevel = 1;
+                }
+                break;
+
+            case "voc":
+                if (sensorValue > 1000) {
+                    dangerLevel = 2;
+                } else if (sensorValue >= 300 && sensorValue <= 1000) {
+                    dangerLevel = 1;
+                }
+                break;
+
+            default:
+                dangerLevel = 0;
+                break;
+        }
+        jsonNode.put("dangerLevel", dangerLevel);
+        return mapper.writeValueAsString(jsonNode);
+    }
+}

--- a/src/main/java/com/monitory/data/transformations/TimeStampAssigner.java
+++ b/src/main/java/com/monitory/data/transformations/TimeStampAssigner.java
@@ -6,15 +6,37 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class TimeStampAssigner implements MapFunction<String, String> {
 
     private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter KST_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
 
     @Override
     public String map(String value) throws Exception {
         ObjectNode jsonNode = (ObjectNode) mapper.readTree(value);
-        jsonNode.put("time", LocalDateTime.now().toString());
+
+        if (jsonNode.has("utc_ingestion_time")) {
+            long utcMillis = jsonNode.get("utc_ingestion_time").asLong();
+
+            Instant utcInstant = Instant.ofEpochMilli(utcMillis);
+
+            ZonedDateTime kstZonedDateTime = utcInstant.atZone(KST_ZONE_ID);
+            String kstTimeString = kstZonedDateTime.format(KST_FORMATTER);
+
+            // 기존 필드 제거 및 새로운 'time' 필드 추가
+            jsonNode.remove("utc_ingestion_time");
+            jsonNode.remove("timezone");
+            jsonNode.put("time", kstTimeString);
+        } else {
+            // utc_ingestion_time 필드가 없는 경우, 현재 KST 시간을 기본값으로 사용하거나 오류 처리
+            ZonedDateTime nowKst = ZonedDateTime.now(KST_ZONE_ID);
+            jsonNode.put("time", nowKst.format(KST_FORMATTER));
+        }
         return mapper.writeValueAsString(jsonNode);
     }
 }

--- a/src/main/java/com/monitory/data/utils/KinesisSourceUtil.java
+++ b/src/main/java/com/monitory/data/utils/KinesisSourceUtil.java
@@ -1,0 +1,44 @@
+package com.monitory.data.utils;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;
+import org.apache.flink.connector.kinesis.source.config.KinesisSourceConfigOptions;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+
+public class KinesisSourceUtil {
+
+    private static final String KINESIS_STREAM_ARN = "arn:aws:kinesis:ap-northeast-2:853660505909:stream/IoTtoFlink";
+    private static final String AWS_REGION = "ap-northeast-2";
+
+    /**
+     * KinesisStreamsSource<String> 객체를 생성하여 반환합니다.
+     * 이 메소드는 Kinesis 스트림 연결에 필요한 설정을 담당합니다.
+     *
+     * @return 구성된 KinesisStreamsSource 인스턴스
+     */
+    public static KinesisStreamsSource<String> createKinesisSource() {
+        Configuration sourceConfig = new Configuration();
+        sourceConfig.setString("aws.region", AWS_REGION);
+        sourceConfig.set(KinesisSourceConfigOptions.STREAM_INITIAL_POSITION, KinesisSourceConfigOptions.InitialPosition.LATEST);
+
+        // 최대 레코드 수 (기본값 10,000 → 500으로 낮춤)
+        sourceConfig.setString(ConsumerConfigConstants.SHARD_GETRECORDS_MAX, "500");
+
+        // GetRecords 호출 간격 (기본 200ms → 3000ms로 증가)
+        sourceConfig.setString(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS, "3000");
+
+        // 재시도 백오프 설정 추가
+        sourceConfig.setString(ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_BASE, "1000");
+        sourceConfig.setString(ConsumerConfigConstants.SHARD_GETRECORDS_BACKOFF_MAX, "5000");
+
+        // KinesisSource 빌더 사용
+        KinesisStreamsSource<String> kinesisStreamsSource = KinesisStreamsSource.<String>builder()
+                .setStreamArn(KINESIS_STREAM_ARN)
+                .setDeserializationSchema(new SimpleStringSchema())
+                .setSourceConfig(sourceConfig)
+                .build();
+
+        return kinesisStreamsSource;
+    }
+}

--- a/src/main/resources/flink-conf.yaml
+++ b/src/main/resources/flink-conf.yaml
@@ -11,7 +11,7 @@ jobmanager:
 taskmanager:
   heap:
     mb: 2048
-  numberOfTaskSlots: 8
+  numberOfTaskSlots: 4
 
 rest:
   port: 8081


### PR DESCRIPTION
## 📌 PR 제목
feat: Kenesis 연동 설정과 이상치 rule-based 라벨링 설정 
---

## ✨ 변경 사항
- IoT Core의 MQTT 메시지를 직접 Flink로 받던 기존 방식에서 IoT Core - Kenesis - Flink로 전달받을 수 있도록 설정하였습니다.
- val 값에 따라 이상치를 판별하여 dangerLabel(0, 1, 2)로 정의하여 전송합니다. 

---


## 📎 관련 이슈
- close: #13 

---
