### PR TITLE
fix: 카프카 토픽 분류 기준 수정 

### DIFF
--- a/src/main/java/com/monitory/data/utils/KafkaUtil.java
+++ b/src/main/java/com/monitory/data/utils/KafkaUtil.java
@@ -19,18 +19,12 @@ public class KafkaUtil {
                             .setTopicSelector((element) -> {
                                 try {
                                     JsonNode json = mapper.readTree(element);
+                                    String category = json.path("category").asText(null);
 
-                                    String zoneId = json.path("zoneId").asText(null);
-                                    String equipId = json.path("equipId").asText(null);
-
-                                    if (zoneId != null && !zoneId.isEmpty() && equipId != null && !equipId.isEmpty()) {
-                                        if (zoneId.equals(equipId)) {
-                                            return "ENVIRONMENT";
-                                        } else {
-                                            return "EQUIPMENT";
-                                        }
+                                    if (category != null && !category.isEmpty()) {
+                                        return category;
                                     } else {
-                                        return "sensor.unknown_topic";
+                                        return "sensor.unknown_category_topic";
                                     }
 
                                 } catch (Exception e) {


### PR DESCRIPTION
## 📌 PR 제목
fix: 카프카 토픽 분류 기준 수정 

---

## ✨ 변경 사항
- equipId와 zoneId 값을 직접 비교하던 기존 방식에서 IoT rule engine에서 추가되는 category 필드값에 따라 토픽을 나눕니다. 
- WEARABLE, ENVIRONMENT, EQUIPMENT에 따라 나눕니다. 

---

## 📎 관련 이슈
- close: #15 

---