### PR TITLE
feat: faulty 여부 설정

### DIFF
--- a/src/main/java/com/monitory/data/FlinkSourceApplication.java
+++ b/src/main/java/com/monitory/data/FlinkSourceApplication.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.monitory.data.sinks.BucketJson;
 import com.monitory.data.sinks.S3WindowFunction;
 import com.monitory.data.transformations.DangerLevelAssigner;
+import com.monitory.data.transformations.FaultyAssigner;
 import com.monitory.data.utils.KinesisSourceUtil;
 import com.monitory.data.utils.S3SinkUtil;
 import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
@@ -61,6 +62,8 @@ public class FlinkSourceApplication {
         // 3-2. 데이터 처리: 이상치 검색
         DataStream<String> labelTransformedStream = timeTransformedStream
                 .map(new DangerLevelAssigner());
+        labelTransformedStream = labelTransformedStream
+                .map(new FaultyAssigner());
 
 
         // 4-1. 데이터 싱크: 콘솔에 출력 & kafka publish

--- a/src/main/java/com/monitory/data/transformations/DangerLevelAssigner.java
+++ b/src/main/java/com/monitory/data/transformations/DangerLevelAssigner.java
@@ -11,86 +11,86 @@ public class DangerLevelAssigner implements MapFunction<String, String>  {
     public String map(String value) throws Exception {
         ObjectNode jsonNode = (ObjectNode) mapper.readTree(value);
 
-        if (jsonNode.has("category") && "EQUIPMENT".equalsIgnoreCase(jsonNode.get("category").asText())) {
-            jsonNode.put("dangerLevel", 0);
+        if (jsonNode.has("category") && "ENVIRONMENT".equalsIgnoreCase(jsonNode.get("category").asText())) {
+            String sensorType = "";
+            double sensorValue = Double.NaN;
+            int dangerLevel = 0;
+
+            if (jsonNode.has("sensorType") && jsonNode.get("sensorType").isTextual()) {
+                sensorType = jsonNode.get("sensorType").asText();
+            } else {
+                jsonNode.put("dangerLevel", "unknown_type");
+                return mapper.writeValueAsString(jsonNode);
+            }
+
+            if (jsonNode.has("val") && jsonNode.get("val").isNumber()) {
+                sensorValue = jsonNode.get("val").asDouble();
+            } else {
+                jsonNode.put("dangerLevel", "invalid_value");
+                return mapper.writeValueAsString(jsonNode);
+            }
+
+            // 출처: https://facto-real.atlassian.net/wiki/spaces/~557058e02db5ec8a1448f1a1ab0ae5d196e126/pages/22806599
+            switch (sensorType.toLowerCase()) {
+                case "temp":
+                    if (sensorValue > 40.0) {
+                        dangerLevel = 2;
+                    } else if (sensorValue < -35) {
+                        dangerLevel = 2;
+                    } else if (sensorValue < 25 || sensorValue > 30) {
+                        dangerLevel = 1;
+                    }
+                    break;
+
+                case "humid":
+                    if (sensorValue >= 80.0) {
+                        dangerLevel = 2;
+                    } else if (sensorValue > 60 && sensorValue < 80.0) {
+                        dangerLevel = 1;
+                    }
+                    break;
+
+                case "vibration":
+                    if (sensorValue > 7.1) {
+                        dangerLevel = 2;
+                    } else if (sensorValue > 2.8 && sensorValue <= 7.1) {
+                        dangerLevel = 1;
+                    }
+                    break;
+
+                case "current":
+                    if (sensorValue > 30) { // 예시 임계값 (ppm)
+                        dangerLevel = 2;
+                    } else if (sensorValue >= 7 && sensorValue <= 30) {
+                        dangerLevel = 1;
+                    }
+                    break;
+
+                case "dust":
+                    if (sensorValue > 150) {
+                        dangerLevel = 2;
+                    } else if (sensorValue > 75 && sensorValue <= 150) {
+                        dangerLevel = 1;
+                    }
+                    break;
+
+                case "voc":
+                    if (sensorValue > 1000) {
+                        dangerLevel = 2;
+                    } else if (sensorValue >= 300 && sensorValue <= 1000) {
+                        dangerLevel = 1;
+                    }
+                    break;
+
+                default:
+                    dangerLevel = 0;
+                    break;
+            }
+            jsonNode.put("dangerLevel", dangerLevel);
             return mapper.writeValueAsString(jsonNode);
         }
-
-        String sensorType = "";
-        double sensorValue = Double.NaN;
-        int dangerLevel = 0;
-
-        if (jsonNode.has("sensorType") && jsonNode.get("sensorType").isTextual()) {
-            sensorType = jsonNode.get("sensorType").asText();
-        } else {
-            jsonNode.put("dangerLevel", "unknown_type");
-            return mapper.writeValueAsString(jsonNode);
+        else {
+            return value;
         }
-
-        if (jsonNode.has("val") && jsonNode.get("val").isNumber()) {
-            sensorValue = jsonNode.get("val").asDouble();
-        } else {
-            jsonNode.put("dangerLevel", "invalid_value");
-            return mapper.writeValueAsString(jsonNode);
-        }
-
-        // 출처: https://facto-real.atlassian.net/wiki/spaces/~557058e02db5ec8a1448f1a1ab0ae5d196e126/pages/22806599
-        switch (sensorType.toLowerCase()) {
-            case "temp":
-                if (sensorValue > 40.0) {
-                    dangerLevel = 2;
-                } else if (sensorValue < -35) {
-                    dangerLevel = 2;
-                } else if (sensorValue < 25 || sensorValue > 30) {
-                    dangerLevel = 1;
-                }
-                break;
-
-            case "humid":
-                if (sensorValue >= 80.0) {
-                    dangerLevel = 2;
-                } else if (sensorValue > 60 && sensorValue < 80.0) {
-                    dangerLevel = 1;
-                }
-                break;
-
-            case "vibration":
-                if (sensorValue > 7.1) {
-                    dangerLevel = 2;
-                } else if (sensorValue > 2.8 && sensorValue <= 7.1) {
-                    dangerLevel = 1;
-                }
-                break;
-
-            case "current":
-                if (sensorValue > 30) { // 예시 임계값 (ppm)
-                    dangerLevel = 2;
-                } else if (sensorValue >= 7 && sensorValue <= 30) {
-                    dangerLevel = 1;
-                }
-                break;
-
-            case "dust":
-                if (sensorValue > 150) {
-                    dangerLevel = 2;
-                } else if (sensorValue > 75 && sensorValue <= 150) {
-                    dangerLevel = 1;
-                }
-                break;
-
-            case "voc":
-                if (sensorValue > 1000) {
-                    dangerLevel = 2;
-                } else if (sensorValue >= 300 && sensorValue <= 1000) {
-                    dangerLevel = 1;
-                }
-                break;
-
-            default:
-                dangerLevel = 0;
-                break;
-        }
-        jsonNode.put("dangerLevel", dangerLevel);
-        return mapper.writeValueAsString(jsonNode);
     }
 }

--- a/src/main/java/com/monitory/data/transformations/FaultyAssigner.java
+++ b/src/main/java/com/monitory/data/transformations/FaultyAssigner.java
@@ -1,0 +1,80 @@
+package com.monitory.data.transformations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.api.common.functions.MapFunction;
+
+public class FaultyAssigner implements MapFunction<String, String>  {
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String map(String value) throws Exception {
+        ObjectNode jsonNode = (ObjectNode) mapper.readTree(value);
+
+        if (jsonNode.has("category") && "EQUIPMENT".equalsIgnoreCase(jsonNode.get("category").asText())) {
+            String sensorType = "";
+            double sensorValue = Double.NaN;
+            int faulty = 1;
+
+            if (jsonNode.has("sensorType") && jsonNode.get("sensorType").isTextual()) {
+                sensorType = jsonNode.get("sensorType").asText();
+            } else {
+                jsonNode.put("dangerLevel", "unknown_type");
+                return mapper.writeValueAsString(jsonNode);
+            }
+
+            if (jsonNode.has("val") && jsonNode.get("val").isNumber()) {
+                sensorValue = jsonNode.get("val").asDouble();
+            } else {
+                jsonNode.put("dangerLevel", "invalid_value");
+                return mapper.writeValueAsString(jsonNode);
+            }
+
+            // 출처: https://facto-real.atlassian.net/wiki/spaces/~557058e02db5ec8a1448f1a1ab0ae5d196e126/pages/26902590
+            switch (sensorType.toLowerCase()) {
+                case "temp":
+                    if ((sensorValue> 61) && (sensorValue < 81)) {
+                        faulty = 0;
+                    }
+                    break;
+
+                case "humid":
+                    if ((sensorValue> 38.18) && (sensorValue < 61.86)) {
+                        faulty = 0;
+                    }
+                    break;
+
+                case "vibration":
+                    if ((sensorValue> 0.88) && (sensorValue < 2.34)) {
+                        faulty = 0;
+                    }
+                    break;
+
+                case "pressure":
+                    if ((sensorValue> 25.36) && (sensorValue < 46.12)) {
+                        faulty = 0;
+                    }
+                    break;
+
+                case "active_power":
+                    if ((sensorValue> 14974) && (sensorValue < 91500)) {
+                        faulty = 0;
+                    }
+                    break;
+
+                case "reactive_power":
+                    if ((sensorValue> 9771) && (sensorValue < 48265)) {
+                        faulty = 0;
+                    }
+                    break;
+                default:
+                    return value;
+            }
+            jsonNode.put("faulty", faulty);
+            return mapper.writeValueAsString(jsonNode);
+        }
+        else {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat: faulty 여부 설정

---

## ✨ 변경 사항
- 센서에서 전송되는 데이터를 설비 예지보전 모델 훈련용으로 사용하기 위해 처리합니다.
- 결함이 있다고 판정되는 센서 데이터의 경우 faulty = 1, 그렇지 않을 경우 0으로 반환합니다. 

---

## 📎 관련 이슈
- close #23 